### PR TITLE
Filter with closures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ random_drop = ["fastrand"]
 [dependencies]
 arc-swap = "1"
 crossbeam-channel = "0.5.0"
+env_filter = "0.1"
 hashbrown = "0.14"
 nohash-hasher = "0.2"
 typed-builder = "0.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ftlog"
 version = "0.2.13"
 edition = "2021"
-authors = [ "Non-convex Tech" ]
+authors = ["Non-convex Tech"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/nonconvextech/ftlog"
@@ -10,41 +10,41 @@ documentation = "https://docs.rs/ftlog"
 description = """
 An asynchronous logging library for high performance
 """
-categories = [ "development-tools::debugging" ]
-keywords = [ "logging" ]
-exclude = [ ".standard-version", ".versionrc", ".github" ]
+categories = ["development-tools::debugging"]
+keywords = ["logging"]
+exclude = [".standard-version", ".versionrc", ".github"]
 
 [features]
-default = [ "random_drop" ]
-tsc = [ "minstant", "once_cell" ]
-random_drop = [ "fastrand" ]
+default = ["random_drop"]
+tsc = ["minstant", "once_cell"]
+random_drop = ["fastrand"]
 
 [dependencies]
+arc-swap = "1"
 crossbeam-channel = "0.5.0"
 hashbrown = "0.14"
-arc-swap = "1"
 nohash-hasher = "0.2"
 typed-builder = "0.16"
 
-  [dependencies.fastrand]
-  version = "2"
-  optional = true
+[dependencies.fastrand]
+version = "2"
+optional = true
 
-  [dependencies.time]
-  version = "0.3"
-  features = [ "local-offset", "formatting" ]
+[dependencies.log]
+version = "0.4"
+features = ["std", "kv_unstable"]
 
-  [dependencies.minstant]
-  version = "0.1"
-  optional = true
+[dependencies.minstant]
+version = "0.1"
+optional = true
 
-  [dependencies.once_cell]
-  version = "1"
-  optional = true
+[dependencies.once_cell]
+version = "1"
+optional = true
 
-  [dependencies.log]
-  version = "0.4"
-  features = [ "std", "kv_unstable" ]
+[dependencies.time]
+version = "0.3"
+features = ["local-offset", "formatting"]
 
 [target."cfg(target_family = \"unix\")".dependencies.tz-rs]
 version = "0.6.14"

--- a/examples/custom-format.rs
+++ b/examples/custom-format.rs
@@ -41,7 +41,7 @@ fn init() -> LoggerGuard {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             f.write_str(&format!(
                 "{}@{}||{}:{}[{}] {}",
-                self.thread.as_ref().map(|x| x.as_str()).unwrap_or(""),
+                self.thread.as_deref().unwrap_or(""),
                 self.module_path.unwrap_or(""),
                 self.file.unwrap_or(""),
                 self.line.unwrap_or(0),
@@ -72,17 +72,17 @@ fn init() -> LoggerGuard {
         )
         // ---------- configure additional filter ----------
         // write to "ftlog-appender" appender, with different level filter
-        .filter(
+        .filter_with(
             |_msg, level, target| target == "ftlog::appender" && level == LevelFilter::Error,
             "ftlog-appender",
         )
         // write to root appender, but with different level filter
-        .filter(
+        .filter_with(
             |_msg, level, target| target == "ftlog" && level == LevelFilter::Trace,
             "ftlog",
         )
         // write to "ftlog" appender, with default level filter
-        .filter(
+        .filter_with(
             |_msg, _level, target| target == "ftlog::appender::file",
             "ftlog",
         )

--- a/examples/custom-format.rs
+++ b/examples/custom-format.rs
@@ -41,7 +41,7 @@ fn init() -> LoggerGuard {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             f.write_str(&format!(
                 "{}@{}||{}:{}[{}] {}",
-                self.thread.as_ref().map(|x| x.as_str()).unwrap_or(""),
+                self.thread.as_deref().unwrap_or(""),
                 self.module_path.unwrap_or(""),
                 self.file.unwrap_or(""),
                 self.line.unwrap_or(0),

--- a/examples/custom-format.rs
+++ b/examples/custom-format.rs
@@ -2,9 +2,9 @@ use std::fmt::Display;
 
 use ftlog::{
     appender::{file::Period, FileAppender},
-    info, FtLogFormat, LoggerGuard,
+    info, FtLogFormat, LoggerGuard, Record,
 };
-use log::{Level, LevelFilter, Record};
+use log::{Level, LevelFilter};
 use time::Duration;
 fn init() -> LoggerGuard {
     // Custom log style.
@@ -41,7 +41,7 @@ fn init() -> LoggerGuard {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             f.write_str(&format!(
                 "{}@{}||{}:{}[{}] {}",
-                self.thread.as_deref().unwrap_or(""),
+                self.thread.as_ref().map(|x| x.as_str()).unwrap_or(""),
                 self.module_path.unwrap_or(""),
                 self.file.unwrap_or(""),
                 self.line.unwrap_or(0),
@@ -72,11 +72,20 @@ fn init() -> LoggerGuard {
         )
         // ---------- configure additional filter ----------
         // write to "ftlog-appender" appender, with different level filter
-        .filter("ftlog::appender", "ftlog-appender", LevelFilter::Error)
+        .filter(
+            |_msg, level, target| target == "ftlog::appender" && level == LevelFilter::Error,
+            "ftlog-appender",
+        )
         // write to root appender, but with different level filter
-        .filter("ftlog", None, LevelFilter::Trace)
+        .filter(
+            |_msg, level, target| target == "ftlog" && level == LevelFilter::Trace,
+            "ftlog",
+        )
         // write to "ftlog" appender, with default level filter
-        .filter("ftlog::appender::file", "ftlog", None)
+        .filter(
+            |_msg, _level, target| target == "ftlog::appender::file",
+            "ftlog",
+        )
         // ----------  configure additional appender ----------
         // new appender
         .appender("ftlog-appender", FileAppender::new("ftlog-appender.log"))

--- a/examples/env_log.rs
+++ b/examples/env_log.rs
@@ -1,0 +1,30 @@
+use ftlog::{appender::FileAppender, LoggerGuard};
+use log::{info, LevelFilter};
+
+fn init() -> LoggerGuard {
+    // Rotate every day, clean stale logs that were modified 7 days ago on each rotation
+    let writer = FileAppender::builder()
+    .path("./env_log.log")
+    .build();
+    ftlog::Builder::new()
+        // global max log level
+        .max_log_level(LevelFilter::Info)
+        .use_env_filter()
+        // define root appender, pass None would write to stderr
+        .root(writer)
+        // write logs in ftlog::appender to "./ftlog-appender.log" instead of "./current.log"
+        .try_init()
+        .expect("logger build or set failed")
+}
+
+fn main() {
+    // RUST_LOG=env_log cargo run --example env_log or RUST_LOG=info cargo run --example env_log will show log lines
+    let _guard = init();
+    info!("Hello, world!");
+    for i in 0..120 {
+        info!("running {}!", i);
+        info!(limit=3000i64; "limit running{} !", i);
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+    std::thread::sleep(std::time::Duration::from_secs(5));
+}

--- a/examples/env_log.rs
+++ b/examples/env_log.rs
@@ -3,9 +3,7 @@ use log::{info, LevelFilter};
 
 fn init() -> LoggerGuard {
     // Rotate every day, clean stale logs that were modified 7 days ago on each rotation
-    let writer = FileAppender::builder()
-    .path("./env_log.log")
-    .build();
+    let writer = FileAppender::builder().path("./env_log.log").build();
     ftlog::Builder::new()
         // global max log level
         .max_log_level(LevelFilter::Info)

--- a/examples/ftlog.rs
+++ b/examples/ftlog.rs
@@ -1,6 +1,5 @@
 use ftlog::{
-    appender::{file::Period, FileAppender},
-    info, LoggerGuard,
+    appender::{file::Period, FileAppender}, LoggerGuard,
 };
 use log::LevelFilter;
 use time::Duration;

--- a/examples/ftlog.rs
+++ b/examples/ftlog.rs
@@ -1,5 +1,6 @@
 use ftlog::{
-    appender::{file::Period, FileAppender}, LoggerGuard,
+    appender::{file::Period, FileAppender},
+    LoggerGuard,
 };
 use log::LevelFilter;
 use time::Duration;
@@ -17,7 +18,10 @@ fn init() -> LoggerGuard {
         // define root appender, pass None would write to stderr
         .root(writer)
         // write logs in ftlog::appender to "./ftlog-appender.log" instead of "./current.log"
-        .filter("ftlog::appender", "ftlog-appender", LevelFilter::Error)
+        .filter(
+            |_msg, level, target| target == "ftlog::appender" && level == LevelFilter::Error,
+            "ftlog-appender",
+        )
         .appender("ftlog-appender", FileAppender::new("ftlog-appender.log"))
         .try_init()
         .expect("logger build or set failed")

--- a/examples/ftlog.rs
+++ b/examples/ftlog.rs
@@ -6,7 +6,7 @@ use log::LevelFilter;
 use time::Duration;
 
 fn init() -> LoggerGuard {
-    // Rotate every day, clean stale logs that were modified 7 days ago on each rotation
+    // Rotate every minute, clean stale logs that were modified 4 minutes ago on each rotation
     let writer = FileAppender::builder()
         .path("./current.log")
         .rotate(Period::Minute)
@@ -18,7 +18,7 @@ fn init() -> LoggerGuard {
         // define root appender, pass None would write to stderr
         .root(writer)
         // write logs in ftlog::appender to "./ftlog-appender.log" instead of "./current.log"
-        .filter(
+        .filter_with(
             |_msg, level, target| target == "ftlog::appender" && level == LevelFilter::Error,
             "ftlog-appender",
         )

--- a/examples/multi-dest.rs
+++ b/examples/multi-dest.rs
@@ -21,7 +21,7 @@ fn init() -> LoggerGuard {
             Box::new(std::io::stdout()),
         ]))
         // write logs in ftlog::appender to "./ftlog-appender.log" instead of "./current.log"
-        .filter(
+        .filter_with(
             |_msg, level, target| target == "ftlog::appender" && level == LevelFilter::Error,
             "ftlog-appender",
         )

--- a/examples/multi-dest.rs
+++ b/examples/multi-dest.rs
@@ -21,7 +21,10 @@ fn init() -> LoggerGuard {
             Box::new(std::io::stdout()),
         ]))
         // write logs in ftlog::appender to "./ftlog-appender.log" instead of "./current.log"
-        .filter("ftlog::appender", "ftlog-appender", LevelFilter::Error)
+        .filter(
+            |_msg, level, target| target == "ftlog::appender" && level == LevelFilter::Error,
+            "ftlog-appender",
+        )
         .appender("ftlog-appender", FileAppender::new("ftlog-appender.log"))
         .try_init()
         .expect("logger build or set failed")

--- a/src/appender/file.rs
+++ b/src/appender/file.rs
@@ -160,8 +160,9 @@ impl<
                 let del_msg = clean_expire_log(p, period, expire);
                 if !del_msg.is_empty() {
                     file.write_fmt(format_args!("Log file deleted: {}", del_msg))
-                        .unwrap_or_else(|_| panic!("Write msg to \"{}\" failed",
-                            path.to_string_lossy()));
+                        .unwrap_or_else(|_| {
+                            panic!("Write msg to \"{}\" failed", path.to_string_lossy())
+                        });
                 }
                 FileAppender {
                     file,
@@ -205,8 +206,12 @@ impl<
                         .create(true)
                         .append(true)
                         .open(&builder.path)
-                        .unwrap_or_else(|_| panic!("Fail to create log file: {}",
-                            builder.path.to_string_lossy())),
+                        .unwrap_or_else(|_| {
+                            panic!(
+                                "Fail to create log file: {}",
+                                builder.path.to_string_lossy()
+                            )
+                        }),
                 ),
                 path: builder.path,
                 rotate: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -418,7 +418,7 @@ impl LogMsg {
             format!("{} {}\n", *missed_entry, msg)
         } else {
             format!("{}\n", msg)
-        }
+        };
         if let Err(e) = writer.write_all(s.as_bytes()) {
             eprintln!("logger write message failed: {}", e);
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -378,7 +378,6 @@ impl LogMsg {
         missed_log: &mut HashMap<u64, i64, nohash_hasher::BuildNoHashHasher<u64>>,
         last_log: &mut HashMap<u64, Time, nohash_hasher::BuildNoHashHasher<u64>>,
     ) {
-
         // Find an appender filter if one exists
         let writer = if let Some(filter) = filters
             .iter()
@@ -395,15 +394,12 @@ impl LogMsg {
             root
         };
 
-
         let msg = self.msg.to_string();
         if msg.is_empty() {
             return;
         }
 
         let now = now();
-
- 
         let s = if self.limit > 0 {
             let missed_entry = missed_log.entry(self.limit_key).or_insert_with(|| 0);
             if let Some(last) = last_log.get(&self.limit_key) {

--- a/tests/local_tz.rs
+++ b/tests/local_tz.rs
@@ -9,9 +9,9 @@ pub fn setup() {
     let logger = ftlog::Builder::new()
         .bounded(10000, true)
         .root(FileAppender::new("./root.log"))
-        .filter("rotate", "rotate", None)
+        .filter(|_msg, _level, target| target == "rotate", "rotate")
         .appender("rotate", FileAppender::rotate("rotate.log", Period::Minute))
-        .filter("expire", "expire", None)
+        .filter(|_msg, _level, target| target == "expire", "expire")
         .appender(
             "expire",
             FileAppender::rotate_with_expire("expire.log", Period::Day, Duration::days(7)),

--- a/tests/local_tz.rs
+++ b/tests/local_tz.rs
@@ -5,7 +5,7 @@ use std::{
 
 use ftlog::appender::{Duration, FileAppender, Period};
 
-pub fn setup() -> () {
+pub fn setup() {
     let logger = ftlog::Builder::new()
         .bounded(10000, true)
         .root(FileAppender::new("./root.log"))
@@ -24,7 +24,6 @@ pub fn setup() -> () {
 fn clean(dir: &str) {
     for file in read_dir(dir)
         .unwrap()
-        .into_iter()
         .filter_map(|x| x.ok())
         .filter(|f| f.file_type().unwrap().is_file())
     {

--- a/tests/local_tz.rs
+++ b/tests/local_tz.rs
@@ -5,13 +5,29 @@ use std::{
 
 use ftlog::appender::{Duration, FileAppender, Period};
 
-pub fn setup() {
+pub fn setup_with_closures() {
     let logger = ftlog::Builder::new()
         .bounded(10000, true)
         .root(FileAppender::new("./root.log"))
-        .filter(|_msg, _level, target| target == "rotate", "rotate")
+        .filter_with(|_msg, _level, target| target == "rotate", "rotate")
         .appender("rotate", FileAppender::rotate("rotate.log", Period::Minute))
-        .filter(|_msg, _level, target| target == "expire", "expire")
+        .filter_with(|_msg, _level, target| target == "expire", "expire")
+        .appender(
+            "expire",
+            FileAppender::rotate_with_expire("expire.log", Period::Day, Duration::days(7)),
+        )
+        .build()
+        .expect("logger build failed");
+    logger.init().expect("set logger failed");
+}
+pub fn setup_with_filter() {
+    let logger = ftlog::Builder::new()
+        .bounded(10000, true)
+        .root(FileAppender::new("./root.log"))
+        // .utc()
+        .filter("rotate", "rotate", None)
+        .appender("rotate", FileAppender::rotate("rotate.log", Period::Minute))
+        .filter("expire", "expire", None)
         .appender(
             "expire",
             FileAppender::rotate_with_expire("expire.log", Period::Day, Duration::days(7)),
@@ -39,9 +55,57 @@ fn clean(dir: &str) {
     }
 }
 #[test]
-fn test_speed() {
+fn test_speed_local() {
     // ~80MB
-    setup();
+    setup_with_filter();
+    let elapsed1 = {
+        // file
+        let now = Instant::now();
+        for i in 1..=1_000_000 {
+            ftlog::info!("file log {}", i);
+        }
+        ftlog::logger().flush();
+        let elapsed = now.elapsed();
+        println!("File elapsed: {}s", elapsed.as_secs_f64());
+        elapsed
+    };
+
+    let elapsed2 = {
+        // file with rotate
+        let now = Instant::now();
+        for i in 1..=1_000_000 {
+            ftlog::info!(target:"rotate", "file log {}", i);
+        }
+        ftlog::logger().flush();
+        let elapsed = now.elapsed();
+        println!("Rotate file elapsed: {}s", elapsed.as_secs_f64());
+        elapsed
+    };
+
+    let elapsed3 = {
+        // file with rotate with expire
+        let now = Instant::now();
+        for i in 1..=1_000_000 {
+            ftlog::info!(target:"expire", "file log {}", i);
+        }
+        ftlog::logger().flush();
+        let elapsed = now.elapsed();
+        println!(
+            "Rotate file with expire elapsed: {}s",
+            elapsed.as_secs_f64()
+        );
+        elapsed
+    };
+    clean("./");
+    assert!(elapsed1.as_secs() < 8);
+    assert!(elapsed2.as_secs() < 8);
+    assert!(elapsed3.as_secs() < 8);
+}
+
+#[test]
+fn test_speed_local2() {
+    // ~80MB
+    setup_with_closures();
     let elapsed1 = {
         // file
         let now = Instant::now();

--- a/tests/utc.rs
+++ b/tests/utc.rs
@@ -10,9 +10,9 @@ pub fn setup() {
         .bounded(10000, true)
         .root(FileAppender::new("./root.log"))
         // .utc()
-        .filter(|_msg, _level, target| target == "rotate", "rotate")
+        .filter_with(|_msg, _level, target| target == "rotate", "rotate")
         .appender("rotate", FileAppender::rotate("rotate.log", Period::Minute))
-        .filter(|_msg, _level, target| target == "expire", "expire")
+        .filter_with(|_msg, _level, target| target == "expire", "expire")
         .appender(
             "expire",
             FileAppender::rotate_with_expire("expire.log", Period::Day, Duration::days(7)),
@@ -40,7 +40,7 @@ fn clean(dir: &str) {
     }
 }
 #[test]
-fn test_speed() {
+fn test_speed_utc() {
     // ~80MB
     setup();
     let elapsed1 = {

--- a/tests/utc.rs
+++ b/tests/utc.rs
@@ -10,9 +10,9 @@ pub fn setup() {
         .bounded(10000, true)
         .root(FileAppender::new("./root.log"))
         // .utc()
-        .filter("rotate", "rotate", None)
+        .filter(|_msg, _level, target| target == "rotate", "rotate")
         .appender("rotate", FileAppender::rotate("rotate.log", Period::Minute))
-        .filter("expire", "expire", None)
+        .filter(|_msg, _level, target| target == "expire", "expire")
         .appender(
             "expire",
             FileAppender::rotate_with_expire("expire.log", Period::Day, Duration::days(7)),

--- a/tests/utc.rs
+++ b/tests/utc.rs
@@ -5,7 +5,7 @@ use std::{
 
 use ftlog::appender::{Duration, FileAppender, Period};
 
-pub fn setup() -> () {
+pub fn setup() {
     let logger = ftlog::Builder::new()
         .bounded(10000, true)
         .root(FileAppender::new("./root.log"))
@@ -25,7 +25,6 @@ pub fn setup() -> () {
 fn clean(dir: &str) {
     for file in read_dir(dir)
         .unwrap()
-        .into_iter()
         .filter_map(|x| x.ok())
         .filter(|f| f.file_type().unwrap().is_file())
     {


### PR DESCRIPTION
Thanks for building ftlog! I've customized it a little bit with this PR. It allows 2 types of closures (filters) to be added. The first type will drop logs before they're ever added into the pipeline. Could be useful for really spammy log entries. The second type allows setting a closure to select the Appender to use. This allows the user to use any criteria they want to redirect logs. The background for this change is I have a desire to redirect log entries based on a key/value pair that's in the log message. So instead of just filtering on the level I want to filter on the message itself. 
I also added in some cargo clippy fixes and some little cleanup things. 